### PR TITLE
Pass option to cheerio to prevent decoding/encoding entities.

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,8 +101,8 @@ declassify.pruneAttrs = function(attrNames, $, ignore) {
 declassify.process = function(htmlInput, options) {
   if (options === void 0) options = {};
 
-  var $ = cheerio.load(htmlInput);
+  var $ = cheerio.load(htmlInput, {decodeEntities: false});
   var ignore = options.ignore || [];
   declassify.pruneAttrs(['id', 'class'], $, ignore);
-  return $.html();
+  return $.html({decodeEntities: false});
 };

--- a/test/assets/special-chars.in.html
+++ b/test/assets/special-chars.in.html
@@ -1,0 +1,30 @@
+<html>
+
+<head>
+    <style>
+    @media only screen and (max-width: 596px) {
+        .parent>.child {
+            color: blue;
+        }
+    }
+    </style>
+</head>
+
+<body style="color: black;">
+    <div class="parent">
+        <div class="child">
+            I should be red by default.
+        </div>
+    </div>
+    <div>
+        Special Characters here:
+        <div>
+            Declassify's a great tool.
+        </div>
+        <div>
+            &lt; Hey &gt; &amp; "'"
+        </div>
+    </div>
+</body>
+
+</html>

--- a/test/assets/special-chars.out.html
+++ b/test/assets/special-chars.out.html
@@ -1,0 +1,30 @@
+<html>
+
+<head>
+    <style>
+    @media only screen and (max-width: 596px) {
+        .parent>.child {
+            color: blue;
+        }
+    }
+    </style>
+</head>
+
+<body style="color: black;">
+    <div class="parent">
+        <div class="child">
+            I should be red by default.
+        </div>
+    </div>
+    <div>
+        Special Characters here:
+        <div>
+            Declassify's a great tool.
+        </div>
+        <div>
+            &lt; Hey &gt; &amp; "'"
+        </div>
+    </div>
+</body>
+
+</html>

--- a/test/index.js
+++ b/test/index.js
@@ -45,6 +45,16 @@ it('processes the HTML and ignores given rules', function() {
           /ignored-regex-id\-[0-9]+/
         ]
       });
+});
+
+it('processes the HTML with quote marks', function() {
+  var input = fs.readFileSync(
+      path.join(__dirname, 'assets', 'special-chars.in.html'), 'utf8');
+
+  var expected = fs.readFileSync(
+      path.join(__dirname, 'assets', 'special-chars.out.html'), 'utf8');
+
+  var result = declassify.process(input);
 
   assert.equal(result, expected);
 });


### PR DESCRIPTION
We are currently experiencing an issue with emails which contain un-encoded single quote marks. It seems like these are consistently being encoded as &apos; by the call to cheerio from within declassify.

This is a workaround for cheerio encoding single quote \\' as &apos; in the text it returns from the .html() method. &apos; does not display properly in older browsers or outlook email clients.
see:
https://github.com/cheeriojs/cheerio/issues/319

