### PR TITLE
Make attributes configurable via option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ var options = {
     /ignored-regex-class\-[0-9]+/,
     'ignored-id',
     /ignored-regex-id\-[0-9]+/
-  ]
+  ],
+  attrs: ['id', 'class']
 };
 var result = declassify.process(html, options);
 ```

--- a/index.js
+++ b/index.js
@@ -103,6 +103,7 @@ declassify.process = function(htmlInput, options) {
 
   var $ = cheerio.load(htmlInput, {decodeEntities: false});
   var ignore = options.ignore || [];
-  declassify.pruneAttrs(['id', 'class'], $, ignore);
+  var attrs = options.attrs || ['id', 'class'];
+  declassify.pruneAttrs(attrs, $, ignore);
   return $.html({decodeEntities: false});
 };


### PR DESCRIPTION
This makes the package more flexible. IDs are often used as anchors for
navigation on the page, so they should not get removed even if no CSS
is attached to them.

It is considered best practice to not style IDs at all and only use them
as anchor links. Therefore many people do not want ID selectors to be
filtered out.

This change makes it possible to easily exclude IDs from the list of
filtered attributes.